### PR TITLE
fix(planner): remove unnecessary use_graphrag parameter and update agentic flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,6 @@ video_agent = VideoAgent(
     url=None,  # Optional: URL to filter out the search results for given url
     use_critic_agent=True,  # Enable critic agent
     stream=False,  # Stream response
-    use_graph_rag=False,  # Optional: use graph RAG
     cache=False  # Optional: enable caching
 )
 

--- a/examples/video_agent.ipynb
+++ b/examples/video_agent.ipynb
@@ -94,7 +94,6 @@
     "    url=None,  # Optional: URL to filter out the documents\n",
     "    use_critic_agent=True,  # Enable critic agent\n",
     "    stream=True,  # Stream response\n",
-    "    use_graph_rag=False,  # Optional: use graph RAG\n",
     "    cache=False  # Optional: enable caching\n",
     ")\n",
     "\n",

--- a/mcp_server/tools/get_context_tool.py
+++ b/mcp_server/tools/get_context_tool.py
@@ -8,12 +8,10 @@ async def get_context_tool(
     index_name: Annotated[str, "vector index name"],
     video_id: Annotated[str, "video id if provided in the instruction"] = None,
     url: Annotated[str, "url if provided in the instruction"] = None,
-    use_graph_rag: Annotated[str, "whether to use graph rag or not"] = 'False',
 ) -> str:
     return await get_context(
         query=query,
         index_name=index_name,
         video_id=video_id,
         url=url,
-        use_graph_rag=use_graph_rag
     )

--- a/mmct/video_pipeline/agents/video_agent.py
+++ b/mmct/video_pipeline/agents/video_agent.py
@@ -78,7 +78,6 @@ class VideoAgent:
         use_critic_agent: Optional[bool] = True,
         stream: bool = False,
         llm_provider: Optional[object] = None,
-        use_graph_rag: Optional[bool] = False,
         cache: Optional[bool] = False
     ):
         # Store parameters
@@ -88,7 +87,6 @@ class VideoAgent:
         self.url = url
         self.use_critic_agent = use_critic_agent
         self.stream = stream
-        self.use_graph_rag = use_graph_rag
         self.cache = cache
         # Initialize configuration and logging
         self.config = MMCTConfig()
@@ -121,7 +119,6 @@ class VideoAgent:
                 index_name=self.index_name,
                 stream=self.stream,
                 llm_provider=self.llm_provider,
-                use_graph_rag=self.use_graph_rag,
                 cache = self.cache
             )
 

--- a/mmct/video_pipeline/core/tools/get_context.py
+++ b/mmct/video_pipeline/core/tools/get_context.py
@@ -36,7 +36,6 @@ async def get_context(
     index_name: Annotated[str, "vector index name"],
     video_id: Annotated[str, "video id if provided in the instruction"] = None,
     url: Annotated[str, "url if provided in the instruction to filter out the search results"] = None,
-    use_graph_rag: Annotated[str, "whether to use graph rag or not"] = 'False',
 ) -> str:
     """
     retreive related documents based on the query from the vector database.
@@ -44,16 +43,7 @@ async def get_context(
     global search_provider, embed_provider
     # embedding the query
     embedding = await embed_provider.embedding(query)
-   
     
-    if use_graph_rag=='True':
-        search_config = SearchConfig(provider="custom_search")
-        search_provider = provider_factory.create_search_provider(
-            search_config.provider, search_config.model_dump()
-        )
-        search_results = await search_provider.search(query=query, index_name="temp",embedding=embedding)
-        return search_results
-
     if url:
         filter_query = f"youtube_url eq '{url}'"
     elif video_id:
@@ -90,5 +80,5 @@ if __name__ == "__main__":
     video_id = "hash-video-id"
     query = "user-query"
     index_name = "index-name"
-    results = asyncio.run(get_context(video_id=video_id, query=query,index_name= index_name,use_graph_rag=True))
+    results = asyncio.run(get_context(video_id=video_id, query=query,index_name= index_name))
     print(results)

--- a/mmct/video_pipeline/core/tools/video_qna.py
+++ b/mmct/video_pipeline/core/tools/video_qna.py
@@ -79,7 +79,6 @@ class VideoQnA:
         use_critic_agent: bool = True,
         index_name: str = None,
         llm_provider: Optional[object] = None,
-        use_graph_rag: bool = False,
         cache: bool = True
     ):
         self.query = query
@@ -87,7 +86,6 @@ class VideoQnA:
         self.use_critic_agent = use_critic_agent
         self.index_name = index_name
         self.url = url
-        self.use_graph_rag = use_graph_rag
         self.cache = cache
 
         # Initialize providers if not provided
@@ -131,7 +129,6 @@ class VideoQnA:
             + (f"\nInstruction:video id:{self.video_id}" if self.video_id is not None else "")
             + (f"\nurl:{self.url}" if self.url is not None else "")
             + (f"\nUse the index name:{self.index_name} to retrieve context.")
-            + (f"\n Set the use_graph_rag as True" if self.use_graph_rag else "")
         )
 
     async def _initialize_agents(self):
@@ -231,7 +228,6 @@ async def video_qna(
     ] = "education-video-index-v2",
     stream: Annotated[bool, "Set to True to return the response as a stream."] = False,
     llm_provider: Optional[object] = None,
-    use_graph_rag: Annotated[bool, "Set to True to use GraphRAG for context retrieval."] = False,
     cache: Annotated[bool, "Set to True to enable cache for model responses."] = True
 ):
     """
@@ -253,7 +249,6 @@ async def video_qna(
         query=query,
         use_critic_agent=use_critic_agent,
         index_name=index_name,
-        use_graph_rag=use_graph_rag,
         llm_provider=llm_provider,
         cache=cache,
     )
@@ -285,7 +280,6 @@ if __name__ == "__main__":
             use_critic_agent=use_critic_agent,
             stream=stream,
             index_name=index_name,
-            use_graph_rag=False,
             cache = False
         )
     )

--- a/mmct/video_pipeline/readme.md
+++ b/mmct/video_pipeline/readme.md
@@ -110,7 +110,6 @@ video_id = None  # Optional: specify specific video ID
 url = None  # Optional: URL for analysis
 use_critic_agent = True  # Enable critical thinking framework
 stream = False  # Flag to stream the logs of the Agentic Flow
-use_graph_rag = False  # Optional: use graph RAG
 cache = False  # Optional: enable caching
 
 video_agent = VideoAgent(
@@ -120,7 +119,6 @@ video_agent = VideoAgent(
     url=url,
     use_critic_agent=use_critic_agent,
     stream=stream,
-    use_graph_rag=use_graph_rag,
     cache=cache
 )
 


### PR DESCRIPTION
- Removed the `use_graphrag` parameter from the `get_context` tool
- Fixed Planner behavior causing unintended search_provider override
- Updated agentic flow and tool invocation logic for consistent context retrieval
- Revised documentation and MCP server docs to reflect the updated flow