### PR TITLE
feat: Add model capabilities system for LLM parameter filtering

### DIFF
--- a/mmct/config/llm_model_capabilities.py
+++ b/mmct/config/llm_model_capabilities.py
@@ -1,0 +1,141 @@
+# mmct/config/llm_model_capabilities.py
+
+from pydantic import BaseModel, Field
+from typing import Dict
+
+class LLMModelCapabilities(BaseModel):
+    """LLM model capabilities."""
+    temperature: bool = Field(..., description="Whether the LLM supports `temperature`.")
+    top_p: bool = Field(..., description="Whether the LLM supports `top_p`.")
+    presence_penalty: bool = Field(..., description="Whether the LLM supports `presence_penalty`.")
+    frequency_penalty: bool = Field(..., description="Whether the LLM supports `frequency_penalty`.")
+    logprobs: bool = Field(..., description="Whether the LLM supports `logprobs`.")
+    top_logprobs: bool = Field(..., description="Whether the LLM supports `top_logprobs`.")
+    logit_bias: bool = Field(..., description="Whether the LLM supports `logit_bias`.")
+    max_tokens: bool = Field(..., description="Whether the LLM supports specifying `max_tokens`.")
+    max_completion_tokens: bool = Field(...,description="Whether the LLM supports specifying `max_completion_tokens`. This is used for reasoning models.")
+    reasoning_effort: bool = Field(..., description="Whether the LLM supports reasoning effort.")
+
+# dictionary of model names and their capabilities
+MODEL_CAPABILITIES: Dict[str, LLMModelCapabilities] = {
+    "o3": LLMModelCapabilities(
+        temperature=False,
+        top_p=False,
+        presence_penalty=False,
+        frequency_penalty=False,
+        logprobs=False,
+        top_logprobs=False,
+        logit_bias=False,
+        max_tokens=False,
+        max_completion_tokens=True,
+        reasoning_effort=True
+    ),
+    "o3-mini": LLMModelCapabilities(
+        temperature=False,
+        top_p=False,
+        presence_penalty=False,
+        frequency_penalty=False,
+        logprobs=False,
+        top_logprobs=False,
+        logit_bias=False,
+        max_tokens=False,
+        max_completion_tokens=True,
+        reasoning_effort=True
+    ),
+    "gpt-5": LLMModelCapabilities(
+        temperature=False,
+        top_p=False,
+        presence_penalty=False,
+        frequency_penalty=False,
+        logprobs=False,
+        top_logprobs=False,
+        logit_bias=False,
+        max_tokens=False,
+        max_completion_tokens=True,
+        reasoning_effort=True
+    ),
+    "gpt-5-mini": LLMModelCapabilities(
+        temperature=False,
+        top_p=False,
+        presence_penalty=False,
+        frequency_penalty=False,
+        logprobs=False,
+        top_logprobs=False,
+        logit_bias=False,
+        max_tokens=False,
+        max_completion_tokens=True,
+        reasoning_effort=True
+    ),
+    "gpt-4.1": LLMModelCapabilities(
+        temperature=True,
+        top_p=True,
+        presence_penalty=True,
+        frequency_penalty=True,
+        logprobs=True,
+        top_logprobs=True,
+        logit_bias=True,
+        max_tokens=True,
+        max_completion_tokens=False,
+        reasoning_effort=False
+    ),
+    "gpt-4.1-mini": LLMModelCapabilities(
+        temperature=True,
+        top_p=True,
+        presence_penalty=True,
+        frequency_penalty=True,
+        logprobs=True,
+        top_logprobs=True,
+        logit_bias=True,
+        max_tokens=True,
+        max_completion_tokens=False,
+        reasoning_effort=False
+    ),
+    "gpt-4o": LLMModelCapabilities(
+        temperature=True,
+        top_p=True,
+        presence_penalty=True,
+        frequency_penalty=True,
+        logprobs=True,
+        top_logprobs=True,
+        logit_bias=True,
+        max_tokens=True,
+        max_completion_tokens=False,
+        reasoning_effort=False
+    ),
+    "gpt-4o-mini": LLMModelCapabilities(
+        temperature=True,
+        top_p=True,
+        presence_penalty=True,
+        frequency_penalty=True,
+        logprobs=True,
+        top_logprobs=True,
+        logit_bias=True,
+        max_tokens=True,
+        max_completion_tokens=False,
+        reasoning_effort=False
+    ),
+    "non-reasoning": LLMModelCapabilities(
+        temperature=True,
+        top_p=True,
+        presence_penalty=True,
+        frequency_penalty=True,
+        logprobs=True,
+        top_logprobs=True,
+        logit_bias=True,
+        max_tokens=True,
+        max_completion_tokens=False,
+        reasoning_effort=False
+    ),
+    "reasoning": LLMModelCapabilities(
+        temperature=False,
+        top_p=False,
+        presence_penalty=False,
+        frequency_penalty=False,
+        logprobs=False,
+        top_logprobs=False,
+        logit_bias=False,
+        max_tokens=False,
+        max_completion_tokens=True,
+        reasoning_effort=True
+    )
+}

--- a/mmct/providers/README.md
+++ b/mmct/providers/README.md
@@ -38,6 +38,110 @@ The `custom_providers/` module is where you add your own provider implementation
 
 ---
 
+## 🎯 Model Capabilities System
+
+The Model Capabilities system provides intelligent parameter management for different LLM models, ensuring that only supported parameters are passed to each model. This is particularly important because **reasoning models** (like o3, o3-mini, gpt-5) and **non-reasoning models** (like gpt-4o, gpt-4.1) support different sets of parameters.
+
+### Why Model Capabilities?
+
+Different LLM models have different parameter support:
+
+- **Reasoning Models** (o3, o3-mini, gpt-5, gpt-5-mini):
+  - ❌ Do NOT support: `temperature`, `top_p`, `presence_penalty`, `frequency_penalty`, `logprobs`, `top_logprobs`, `logit_bias`, `max_tokens`
+  - ✅ Support: `max_completion_tokens`, `reasoning_effort`
+
+- **Non-Reasoning Models** (gpt-4o, gpt-4.1, gpt-4o-mini):
+  - ✅ Support: `temperature`, `top_p`, `presence_penalty`, `frequency_penalty`, `logprobs`, `top_logprobs`, `logit_bias`, `max_tokens`
+  - ❌ Do NOT support: `max_completion_tokens`, `reasoning_effort`
+
+### Configuration File
+
+Model capabilities are defined in `mmct/config/llm_model_capabilities.py`:
+
+```python
+from pydantic import BaseModel, Field
+from typing import Dict
+
+class LLMModelCapabilities(BaseModel):
+    """LLM model capabilities."""
+    temperature: bool
+    top_p: bool
+    presence_penalty: bool
+    frequency_penalty: bool
+    logprobs: bool
+    top_logprobs: bool
+    logit_bias: bool
+    max_tokens: bool
+    max_completion_tokens: bool
+    reasoning_effort: bool
+
+MODEL_CAPABILITIES: Dict[str, LLMModelCapabilities] = {
+    "o3": LLMModelCapabilities(...),  # Reasoning model
+    "gpt-4o": LLMModelCapabilities(...),  # Non-reasoning model
+    "non-reasoning": LLMModelCapabilities(...),  # Fallback template
+    "reasoning": LLMModelCapabilities(...),  # Fallback template
+}
+```
+
+### How It Works
+
+Both OpenAI and Azure LLM providers automatically:
+
+1. **Check model capabilities** when making API calls
+2. **Filter parameters** based on what the model supports
+3. **Use fallback** if model is not defined (defaults to "non-reasoning" capabilities)
+4. **Log warnings** when using undefined models
+
+**Example from OpenAI Provider:**
+
+```python
+# Get model capabilities
+caps = MODEL_CAPABILITIES.get(model_name)
+if caps is None:
+    logger.warning(f"No capabilities defined for model `{model_name}`, using non-reasoning capabilities.")
+    caps = MODEL_CAPABILITIES.get("non-reasoning")
+
+# Apply only supported parameters
+for param in LLMModelCapabilities.model_fields.keys():
+    if caps is None or getattr(caps, param, False):
+        call_args[param] = kwargs.get(param, self.config.get(param))
+```
+
+### Adding a New Model
+
+To add support for a new model, update `mmct/config/llm_model_capabilities.py`:
+
+```python
+MODEL_CAPABILITIES: Dict[str, LLMModelCapabilities] = {
+    # ... existing models ...
+    
+    "your-new-model": LLMModelCapabilities(
+        temperature=True,           # Does it support temperature?
+        top_p=True,                 # Does it support top_p?
+        presence_penalty=True,      # Does it support presence_penalty?
+        frequency_penalty=True,     # Does it support frequency_penalty?
+        logprobs=False,             # Does it support logprobs?
+        top_logprobs=False,         # Does it support top_logprobs?
+        logit_bias=False,           # Does it support logit_bias?
+        max_tokens=True,            # Does it support max_tokens?
+        max_completion_tokens=False,  # Does it support max_completion_tokens? (reasoning models)
+        reasoning_effort=False      # Does it support reasoning_effort? (reasoning models)
+    ),
+}
+```
+
+### Fallback Behavior
+
+If a model is not defined in `MODEL_CAPABILITIES`:
+
+1. A **warning is logged**: `"No capabilities defined for model 'model-name', using non-reasoning capabilities."`
+2. The system uses the **"non-reasoning"** template (supports standard parameters like temperature, top_p, etc.)
+3. The code **continues to run** without errors
+
+This ensures backward compatibility when adding new models.
+
+---
+
 ## 🚀 Adding a Custom Provider
 
 Follow these steps to add your own provider implementation (search provider example is given below):

--- a/mmct/providers/azure_providers/llm_provider.py
+++ b/mmct/providers/azure_providers/llm_provider.py
@@ -1,13 +1,14 @@
-from mmct.providers.base import LLMProvider
 from loguru import logger
-from openai import AsyncAzureOpenAI, AzureOpenAI
-from azure.identity import get_bearer_token_provider
-from mmct.utils.error_handler import ProviderException, ConfigurationException
 from typing import Dict, Any, List
-from mmct.utils.error_handler import handle_exceptions, convert_exceptions
+from openai import AsyncAzureOpenAI
+from mmct.providers.base import LLMProvider
+from pydantic import BaseModel as PydanticBaseModel
+from azure.identity import get_bearer_token_provider
 from mmct.providers.credentials import AzureCredentials
+from mmct.utils.error_handler import handle_exceptions, convert_exceptions
+from mmct.utils.error_handler import ProviderException, ConfigurationException
 from autogen_ext.models.openai import AzureOpenAIChatCompletionClient
-
+from mmct.config.llm_model_capabilities import MODEL_CAPABILITIES, LLMModelCapabilities
 
 class AzureLLMProvider(LLMProvider):
     """Azure OpenAI LLM provider implementation."""
@@ -64,26 +65,42 @@ class AzureLLMProvider(LLMProvider):
             deployment_name = self.config.get("deployment_name")
             if not deployment_name:
                 raise ConfigurationException("Azure OpenAI deployment name is required")
+
+            # Build the request kwargs
+            filtered_kwargs = {
+                k: v for k, v in kwargs.items()
+                if k not in LLMModelCapabilities.model_fields.keys()
+            }
+
+            # Build the API call args
+            call_args: Dict[str, Any] = {
+                "model": deployment_name,
+                "messages": messages,
+                **filtered_kwargs,
+            }
+
+            model_name = self.config.get("model_name")  # assuming you store model name in config
+            caps = MODEL_CAPABILITIES.get(model_name)
+            if caps is None:
+                logger.warning(f"No capabilities defined for model `{model_name}`, using non-reasoning capabilities.")
+                caps = MODEL_CAPABILITIES.get("non-reasoning")
+            else:
+                logger.info(f"Model capabilities set to: {caps}")
             
-            temperature = kwargs.get("temperature", self.config.get("temperature", 0.0))
-            max_tokens = kwargs.get("max_tokens", 4000)
-            response_format = kwargs.get("response_format")
-            
-            # Remove temperature, max_tokens, and response_format from kwargs to avoid duplicate arguments
-            filtered_kwargs = {k: v for k, v in kwargs.items() if k not in ["temperature", "max_tokens", "response_format"]}
-            
-            # Check if response_format is a BaseModel - if so, use parse() instead of create()
-            from pydantic import BaseModel
-            if response_format and isinstance(response_format, type) and issubclass(response_format, BaseModel):
+            for param in LLMModelCapabilities.model_fields.keys():
+                # If caps is None, assume full support; otherwise check capability
+                if caps is None or getattr(caps, param, False):
+                    call_args[param] = kwargs.get(param, self.config.get(param))
+
+            response_format = kwargs.pop("response_format", None)
+            if response_format and isinstance(response_format, type) and issubclass(response_format, PydanticBaseModel):
+                if 'response_format' in call_args:
+                    del call_args['response_format']
+
                 response = await self.client.chat.completions.parse(
-                    model=deployment_name,
-                    messages=messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    response_format=response_format,
-                    **filtered_kwargs
+                    **call_args,
+                    response_format=response_format
                 )
-                
                 return {
                     "content": response.choices[0].message.parsed,
                     "usage": response.usage.model_dump() if response.usage else None,
@@ -91,20 +108,7 @@ class AzureLLMProvider(LLMProvider):
                     "finish_reason": response.choices[0].finish_reason
                 }
             else:
-                # Standard completion without structured output
-                completion_kwargs = {
-                    "model": deployment_name,
-                    "messages": messages,
-                    "temperature": temperature,
-                    "max_tokens": max_tokens,
-                    **filtered_kwargs
-                }
-                
-                if response_format:
-                    completion_kwargs["response_format"] = response_format
-                
-                response = await self.client.chat.completions.create(**completion_kwargs)
-                
+                response = await self.client.chat.completions.create(**call_args)
                 return {
                     "content": response.choices[0].message.content,
                     "usage": response.usage.model_dump() if response.usage else None,
@@ -123,7 +127,23 @@ class AzureLLMProvider(LLMProvider):
             api_version = self.config.get("api_version", "2024-08-01-preview")
             use_managed_identity = self.config.get("use_managed_identity", True)
             timeout = self.config.get("timeout", 200)
-            temperature = self.config.get("temperature", 0)
+
+            model_name = self.config.get("model_name")
+            caps = MODEL_CAPABILITIES.get(model_name)
+
+            if caps is None:
+                logger.warning(f"No capabilities defined for model `{model_name}`, using non-reasoning capabilities.")
+                caps = MODEL_CAPABILITIES.get("non-reasoning")
+            else:
+                logger.info(f"Model capabilities set to: {caps}")
+            
+            # Apply model capabilities using a loop for cleaner code
+            model_args: Dict[str, Any] = {}
+            
+            for param in LLMModelCapabilities.model_fields.keys():
+                # If caps is None, assume full support; otherwise check capability
+                if caps is None or getattr(caps, param, False):
+                    model_args[param] = self.config.get(param)
 
             if not endpoint or not deployment_name:
                 raise ConfigurationException("Azure OpenAI endpoint and deployment name are required for autogen client")
@@ -140,7 +160,7 @@ class AzureLLMProvider(LLMProvider):
                     azure_endpoint=endpoint,
                     azure_ad_token_provider=token_provider,
                     timeout=timeout,
-                    temperature=temperature
+                    **model_args,
                 )
             else:
                 api_key = self.config.get("api_key")
@@ -154,7 +174,7 @@ class AzureLLMProvider(LLMProvider):
                     azure_endpoint=endpoint,
                     api_key=api_key,
                     timeout=timeout,
-                    temperature=temperature
+                    **model_args,
                 )
         except Exception as e:
             raise ProviderException(f"Failed to create Azure OpenAI autogen client: {e}")

--- a/mmct/providers/openai_providers/llm_provider.py
+++ b/mmct/providers/openai_providers/llm_provider.py
@@ -1,11 +1,12 @@
-from mmct.providers.base import LLMProvider
 from loguru import logger
-from mmct.utils.error_handler import ProviderException, ConfigurationException
+from openai import AsyncOpenAI
 from typing import Dict, Any, List
-from mmct.utils.error_handler import handle_exceptions, convert_exceptions
-from openai import AsyncOpenAI, OpenAI
+from mmct.providers.base import LLMProvider
+from pydantic import BaseModel as PydanticBaseModel
 from autogen_ext.models.openai import OpenAIChatCompletionClient
-
+from mmct.utils.error_handler import ProviderException, ConfigurationException
+from mmct.utils.error_handler import handle_exceptions, convert_exceptions
+from mmct.config.llm_model_capabilities import MODEL_CAPABILITIES, LLMModelCapabilities
 
 class OpenAILLMProvider(LLMProvider):
     """OpenAI LLM provider implementation."""
@@ -37,26 +38,42 @@ class OpenAILLMProvider(LLMProvider):
     async def chat_completion(self, messages: List[Dict], **kwargs) -> Dict[str, Any]:
         """Generate chat completion using OpenAI."""
         try:
-            model = self.config.get("model_name", "gpt-4o")
-            temperature = kwargs.get("temperature", self.config.get("temperature", 0.0))
-            max_tokens = kwargs.get("max_tokens", 4000)
+            model_name = self.config.get("model_name")
+            
+            # Build the request kwargs, filtering out parameters we'll handle separately
+            filtered_kwargs = {
+                k: v for k, v in kwargs.items()
+                if k not in LLMModelCapabilities.model_fields.keys()
+            }
+
+            # Build the API call args
+            call_args: Dict[str, Any] = {
+                "model": model_name,
+                "messages": messages,
+                **filtered_kwargs,
+            }
+
+            caps = MODEL_CAPABILITIES.get(model_name)
+            if caps is None:
+                logger.warning(f"No capabilities defined for model `{model_name}`, using non-reasoning capabilities.")
+                caps = MODEL_CAPABILITIES.get("non-reasoning")
+            else:
+                logger.info(f"Model capabilities set to: {caps}")
+            
+            for param in LLMModelCapabilities.model_fields.keys():
+                # If caps is None, assume full support; otherwise check capability
+                if caps is None or getattr(caps, param, False):
+                    call_args[param] = kwargs.get(param, self.config.get(param))
+
             response_format = kwargs.get("response_format")
-            
-            # Remove temperature, max_tokens, and response_format from kwargs to avoid duplicate arguments
-            filtered_kwargs = {k: v for k, v in kwargs.items() if k not in ["temperature", "max_tokens", "response_format"]}
-            
-            # Check if response_format is a BaseModel - if so, use parse() instead of create()
-            from pydantic import BaseModel
-            if response_format and isinstance(response_format, type) and issubclass(response_format, BaseModel):
+            if response_format and isinstance(response_format, type) and issubclass(response_format, PydanticBaseModel):
+                if 'response_format' in call_args:
+                    del call_args['response_format']
+
                 response = await self.client.chat.completions.parse(
-                    model=model,
-                    messages=messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    response_format=response_format,
-                    **filtered_kwargs
+                    **call_args,
+                    response_format=response_format
                 )
-                
                 return {
                     "content": response.choices[0].message.parsed,
                     "usage": response.usage.model_dump() if response.usage else None,
@@ -64,20 +81,7 @@ class OpenAILLMProvider(LLMProvider):
                     "finish_reason": response.choices[0].finish_reason
                 }
             else:
-                # Standard completion without structured output
-                completion_kwargs = {
-                    "model": model,
-                    "messages": messages,
-                    "temperature": temperature,
-                    "max_tokens": max_tokens,
-                    **filtered_kwargs
-                }
-                
-                if response_format:
-                    completion_kwargs["response_format"] = response_format
-                
-                response = await self.client.chat.completions.create(**completion_kwargs)
-                
+                response = await self.client.chat.completions.create(**call_args)
                 return {
                     "content": response.choices[0].message.content,
                     "usage": response.usage.model_dump() if response.usage else None,
@@ -95,15 +99,30 @@ class OpenAILLMProvider(LLMProvider):
             if not api_key:
                 raise ConfigurationException("OpenAI API key is required for autogen client")
 
-            model = self.config.get("model_name", "gpt-4o")
+            model_name = self.config.get("model_name")
             timeout = self.config.get("timeout", 200)
-            temperature = self.config.get("temperature", 0)
+
+            caps = MODEL_CAPABILITIES.get(model_name)
+
+            if caps is None:
+                logger.warning(f"No capabilities defined for model `{model_name}`, using non-reasoning capabilities.")
+                caps = MODEL_CAPABILITIES.get("non-reasoning")
+            else:
+                logger.info(f"Model capabilities set to: {caps}")
+            
+            # Apply model capabilities using a loop for cleaner code
+            model_args: Dict[str, Any] = {}
+           
+            for param in LLMModelCapabilities.model_fields.keys():
+                # If caps is None, assume full support; otherwise check capability
+                if caps is None or getattr(caps, param, False):
+                    model_args[param] = self.config.get(param)
 
             return OpenAIChatCompletionClient(
                 api_key=api_key,
                 timeout=timeout,
-                model=model,
-                temperature=temperature
+                model=model_name,
+                **model_args,
             )
         except Exception as e:
             raise ProviderException(f"Failed to create OpenAI autogen client: {e}")


### PR DESCRIPTION
Implemented parameter management to handle different capabilities between reasoning models (example `o3`, `gpt-5`) and non-reasoning models (ex. `gpt-4o`). Only supported parameters are now passed to each model.

- Add MODEL_CAPABILITIES configuration with per-model parameter support.
- Update OpenAI and Azure providers with capability-based filtering.
- Add comprehensive documentation in providers README.
- Include fallback behavior for undefined models.