### PR TITLE
fix: use provided video_id in pre-validation

### DIFF
--- a/mmct/video_pipeline/core/ingestion/pipelines/steps/pre_validation_step.py
+++ b/mmct/video_pipeline/core/ingestion/pipelines/steps/pre_validation_step.py
@@ -32,7 +32,6 @@ class PreValidationStep(PipelineStep):
         # ============================================================
         try:
             context.logger.debug("1. Checking if video already ingested...")
-            # User request: strictly use context.video_id, no internal generation
 
             is_already_ingested = await check_video_already_ingested(
                 hash_id=context.video_id,


### PR DESCRIPTION
## Summary
Updated the [PreValidationStep] to strictly use the provided `context.video_id` for checking if a video has already been ingested, rather than calculating a file hash internally. Additionally, removed the `skip_if_exists` parameter, establishing a default behavior where the pipeline always skips processing if the video ID is found in the index.

## Changes
- Removed internal `get_file_hash` usage in favor of `context.video_id`.
- Removed `skip_if_exists` parameter; the step now enforces skipping if the video is already ingested.
- Cleaned up related logic and comments.